### PR TITLE
Bug fix: render buttons in Live Preview mode when Obsidian starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,13 @@ Note: swap count is reset if you close the note.
 
 ## Releases
 
+### Next version (not released yet)
+
+- Bugfix: buttons now render in Live Preview mode when Obsidian starts ([Lx])
+
+[Lx]: https://github.com/Lx
+
+
 ### 0.4.4
 - Bugfix: blue and purple colors should now work
 - Bugfix: reduced the height of the Button Maker for smaller displays

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,18 +92,21 @@ export default class ButtonsPlugin extends Plugin {
       callback: () => new InlineButtonModal(this.app).open(),
     });
 
-    this.registerMarkdownCodeBlockProcessor("button", async (source, el) => {
-      // create an object out of the arguments
-      const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-      if (activeView) {
-        addButtonToStore(this.app, activeView.file);
+    this.registerMarkdownCodeBlockProcessor(
+      "button",
+      async (source, el, ctx) => {
+        // create an object out of the arguments
+        const file = this.app.vault
+          .getFiles()
+          .find((f) => f.path === ctx.sourcePath);
+        addButtonToStore(this.app, file);
         let args = createArgumentObject(source);
         const storeArgs = await getButtonFromStore(this.app, args);
         args = storeArgs ? storeArgs.args : args;
         const id = storeArgs && storeArgs.id;
         createButton({ app: this.app, el, args, inline: false, id });
       }
-    });
+    );
 
     this.registerMarkdownPostProcessor(async (el, ctx) => {
       // Search for <code> blocks inside this element; for each one, look for things of the form `


### PR DESCRIPTION
Thank you for your efforts on the Obsidian Buttons plugin.

This pull request addresses an issue where buttons would not display in Live Preview immediately after Obsidian starts, due to the "active view" not being fully initialised before Markdown processing commences.

I appreciate that you're working on a new version of Buttons but I think this fix might benefit others in the meantime if you would be willing to release it.