### PR TITLE
Bug fix: improve `templater` option reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,13 @@ Note: swap count is reset if you close the note.
 
 ## Releases
 
+### Next version (not released yet)
+
+- Bugfix: improve reliability of `templater` option ([Lx])
+
+[Lx]: https://github.com/Lx
+
+
 ### 0.4.4
 - Bugfix: blue and purple colors should now work
 - Bugfix: reduced the height of the Button Maker for smaller displays

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -263,50 +263,7 @@ export const templater = async (
     const content = await app.vault.cachedRead(file);
     await runTemplater(app);
     const { args } = await getNewArgs(app, position);
-    const cachedData: string[] = [];
-    const cacheChange = app.vault.on("modify", (file) => {
-      cachedData.push(file.unsafeCachedData);
-    });
-    setTimeout(async () => {
-      const button = content
-        .split("\n")
-        .splice(position.lineStart, position.lineEnd - position.lineStart + 2)
-        .join("\n");
-      let finalContent;
-      if (cachedData[0]) {
-        const cachedContent = cachedData[cachedData.length - 1].split("\n");
-        let addOne = false;
-        if (args.type.includes("prepend")) {
-          addOne = true;
-        } else if (args.type.includes("line")) {
-          const lineNumber = args.type.match(/(\d+)/g);
-          if (lineNumber[0]) {
-            const line = parseInt(lineNumber[0]) - 1;
-            if (line < position.lineStart && !args.replace) {
-              addOne = true;
-            }
-          }
-        }
-        if (addOne) {
-          cachedContent.splice(
-            position.lineStart + 1,
-            position.lineEnd - position.lineStart + 2,
-            button
-          );
-        }  else {
-          cachedContent.splice(
-            position.lineStart,
-            position.lineEnd - position.lineStart + 2,
-            button
-          );
-        }
-        finalContent = cachedContent.join("\n");
-      } else {
-        finalContent = content;
-      }
-      await app.vault.modify(file, finalContent);
-      app.metadataCache.offref(cacheChange);
-    }, 200);
+    await app.vault.modify(file, content);
     return args;
   }
 };

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -15,7 +15,7 @@ import {
   getInlineButtonPosition,
   findNumber,
 } from "./parser";
-import { handleValueArray, getNewArgs } from "./utils";
+import { handleValueArray, getNewArgs, runTemplater } from "./utils";
 import {
   getButtonSwapById,
   setButtonSwapById,
@@ -261,9 +261,7 @@ export const templater = async (
     await activeView.save();
     const file = activeView.file;
     const content = await app.vault.cachedRead(file);
-    app.commands.executeCommandById(
-      "templater-obsidian:replace-in-file-templater"
-    );
+    await runTemplater(app);
     const { args } = await getNewArgs(app, position);
     const cachedData: string[] = [];
     const cacheChange = app.vault.on("modify", (file) => {

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -256,9 +256,9 @@ export const templater = async (
   app: App,
   position: Position
 ): Promise<Arguments> => {
-  app.commands.executeCommandById("editor:save-file");
   const activeView = app.workspace.getActiveViewOfType(MarkdownView);
   if (activeView) {
+    await activeView.save();
     const file = activeView.file;
     const content = await app.vault.cachedRead(file);
     app.commands.executeCommandById(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,25 +92,20 @@ export const handleValueArray = (
   }
 };
 
-export function getNewArgs(
+export async function getNewArgs(
   app: App,
   position: Position
-): Promise<{ args: Arguments; content: string }> {
-  const promise = new Promise((resolve) => {
-    setTimeout(async () => {
-      const activeView = app.workspace.getActiveViewOfType(MarkdownView);
-      const newContent = await app.vault
-        .cachedRead(activeView.file)
-        .then((content: string) => content.split("\n"));
-      const newButton = newContent
-        .splice(position.lineStart, position.lineEnd - position.lineStart)
-        .join("\n")
-        .replace("```button", "")
-        .replace("```", "");
-      resolve({ args: createArgumentObject(newButton) });
-    }, 150);
-  });
-  return promise as Promise<{ args: Arguments; content: string }>;
+): Promise<{ args: Arguments }> {
+  const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+  const newContent = await app.vault
+    .cachedRead(activeView.file)
+    .then((content: string) => content.split("\n"));
+  const newButton = newContent
+    .splice(position.lineStart, position.lineEnd - position.lineStart)
+    .join("\n")
+    .replace("```button", "")
+    .replace("```", "");
+  return { args: createArgumentObject(newButton) };
 }
 
 export const wrapAround = (value: number, size: number): number => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,3 +116,25 @@ export function getNewArgs(
 export const wrapAround = (value: number, size: number): number => {
   return ((value % size) + size) % size;
 };
+
+/**
+ * Run Templater's "Replace templates in the active file" command and wait until complete.
+ */
+export const runTemplater = (
+  app: App
+): Promise<{
+  file: TFile;
+  content: string;
+}> =>
+  new Promise((resolve) => {
+    const ref = app.workspace.on(
+      "templater:overwrite-file",
+      (file: TFile, content: string) => {
+        app.workspace.offref(ref);
+        resolve({ file, content });
+      }
+    );
+    app.commands.executeCommandById(
+      "templater-obsidian:replace-in-file-templater"
+    );
+  });


### PR DESCRIPTION
This pull request improves the reliability and speed of the `templater` option.

The following things are addressed:
- unsaved text is no longer lost when pressing the button (fixes #95)
- template reliably remains in the button definition, not overwritten (fixes #82)
- `await`-ed Templater prompt commands now work (fixes #70 and possibly part of #59?)
- proper order of operations is guaranteed through use of `await` instead of `setTimeout`
  - as a side bonus, the operations happen more quickly.

I appreciate that you're working on a new version of Buttons but I think this fix might benefit others in the meantime if you would be willing to release it.