### PR TITLE
Faster `remove`

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,13 @@ Note: swap count is reset if you close the note.
 
 ## Releases
 
+### Next version (not released yet)
+
+- Bugfix: improve reliability of `templater` option ([Lx])
+
+[Lx]: https://github.com/Lx
+
+
 ### 0.4.4
 - Bugfix: blue and purple colors should now work
 - Bugfix: reduced the height of the Button Maker for smaller displays

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Note: swap count is reset if you close the note.
 ### Next version (not released yet)
 
 - Bugfix: improve reliability of `templater` option ([Lx])
+- improve speed of `remove` option ([Lx])
 
 [Lx]: https://github.com/Lx
 

--- a/src/button.ts
+++ b/src/button.ts
@@ -79,41 +79,35 @@ const clickHandler = async (
   }
   // handle template buttons
   if (args.type && args.type.includes("template")) {
-    setTimeout(async () => {
-      content = await app.vault.read(activeView.file);
-      position = inline
-        ? await getInlineButtonPosition(app, id)
-        : getButtonPosition(content, args);
-      template(app, args, position);
-    }, 50);
+    content = await app.vault.read(activeView.file);
+    position = inline
+      ? await getInlineButtonPosition(app, id)
+      : getButtonPosition(content, args);
+    await template(app, args, position);
   }
   if (args.type === "calculate") {
-    calculate(app, args, position);
+    await calculate(app, args, position);
   }
   if (args.type && args.type.includes("text")) {
-    setTimeout(async () => {
-      content = await app.vault.read(activeView.file);
-      position = inline
-        ? await getInlineButtonPosition(app, id)
-        : getButtonPosition(content, args);
-      text(app, args, position);
-    }, 50);
-  }
-  // handle removing the button
-  if (args.remove) {
-    setTimeout(async () => {
-      content = await app.vault.read(activeView.file);
-      position = inline
-        ? await getInlineButtonPosition(app, id)
-        : getButtonPosition(content, args);
-      remove(app, args, position);
-    }, 1000);
+    content = await app.vault.read(activeView.file);
+    position = inline
+      ? await getInlineButtonPosition(app, id)
+      : getButtonPosition(content, args);
+    await text(app, args, position);
   }
   if (args.swap) {
     if (!inline) {
       new Notice("swap args only work in inline buttons for now", 2000);
     } else {
-      swap(app, args.swap, id, inline, activeView.file);
+      await swap(app, args.swap, id, inline, activeView.file);
     }
+  }
+  // handle removing the button
+  if (args.remove) {
+    content = await app.vault.read(activeView.file);
+    position = inline
+      ? await getInlineButtonPosition(app, id)
+      : getButtonPosition(content, args);
+    await remove(app, args, position);
   }
 };

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -54,16 +54,19 @@ export const calculate = async (
   fun && appendContent(app, `Result: ${fun}`, position.lineEnd);
 };
 
-export const remove = (
+export const remove = async (
   app: App,
   { remove }: Arguments,
   { lineStart, lineEnd }: { lineStart: number; lineEnd: number }
-): void => {
-  setTimeout(() => removeButton(app, remove, lineStart, lineEnd), 1000);
+): Promise<void> => {
+  await removeButton(app, remove, lineStart, lineEnd);
 };
 
-export const replace = (app: App, { replace }: Arguments): void => {
-  removeSection(app, replace);
+export const replace = async (
+  app: App,
+  { replace }: Arguments
+): Promise<void> => {
+  await removeSection(app, replace);
 };
 export const text = async (
   app: App,
@@ -72,17 +75,17 @@ export const text = async (
 ): Promise<void> => {
   // prepend template above the button
   if (args.type.includes("prepend")) {
-    prependContent(app, args.action, position.lineStart);
+    await prependContent(app, args.action, position.lineStart);
   }
   // append template below the button
   if (args.type.includes("append")) {
-    appendContent(app, args.action, position.lineEnd);
+    await appendContent(app, args.action, position.lineEnd);
   }
   if (args.type.includes("note")) {
-    createNote(app, args.action, args.type);
+    await createNote(app, args.action, args.type);
   }
   if (args.type.includes("line")) {
-    addContentAtLine(app, args.action, args.type);
+    await addContentAtLine(app, args.action, args.type);
   }
 };
 
@@ -122,38 +125,20 @@ export const template = async (
       const content = await app.vault.read(file);
       // prepend template above the button
       if (args.type.includes("prepend")) {
-        prependContent(app, content, position.lineStart);
-        setTimeout(
-          () =>
-            app.commands.executeCommandById(
-              "templater-obsidian:replace-in-file-templater"
-            ),
-          100
-        );
+        await prependContent(app, content, position.lineStart);
+        await runTemplater(app);
       }
       // append template below the button
       if (args.type.includes("append")) {
-        appendContent(app, content, position.lineEnd);
-        setTimeout(
-          () =>
-            app.commands.executeCommandById(
-              "templater-obsidian:replace-in-file-templater"
-            ),
-          100
-        );
+        await appendContent(app, content, position.lineEnd);
+        await runTemplater(app);
       }
       if (args.type.includes("note")) {
-        createNote(app, content, args.type);
+        await createNote(app, content, args.type);
       }
       if (args.type.includes("line")) {
-        addContentAtLine(app, content, args.type);
-        setTimeout(
-          () =>
-            app.commands.executeCommandById(
-              "templater-obsidian:replace-in-file-templater"
-            ),
-          100
-        );
+        await addContentAtLine(app, content, args.type);
+        await runTemplater(app);
       }
     } else {
       new Notice(
@@ -204,7 +189,7 @@ export const swap = async (
         }
       }
       if (args.replace) {
-        replace(app, args);
+        await replace(app, args);
       }
       if (args.type === "command") {
         command(app, args);
@@ -215,38 +200,32 @@ export const swap = async (
       }
       // handle template buttons
       if (args.type && args.type.includes("template")) {
-        setTimeout(async () => {
-          content = await app.vault.read(file);
-          position = inline
-            ? await getInlineButtonPosition(app, id)
-            : getButtonPosition(content, args);
-          template(app, args, position);
-        }, 50);
+        content = await app.vault.read(file);
+        position = inline
+          ? await getInlineButtonPosition(app, id)
+          : getButtonPosition(content, args);
+        await template(app, args, position);
       }
       if (args.type === "calculate") {
-        calculate(app, args, position);
+        await calculate(app, args, position);
       }
       if (args.type && args.type.includes("text")) {
-        setTimeout(async () => {
-          content = await app.vault.read(file);
-          position = inline
-            ? await getInlineButtonPosition(app, id)
-            : getButtonPosition(content, args);
-          text(app, args, position);
-        }, 50);
+        content = await app.vault.read(file);
+        position = inline
+          ? await getInlineButtonPosition(app, id)
+          : getButtonPosition(content, args);
+        await text(app, args, position);
       }
       // handle removing the button
       if (args.remove) {
-        setTimeout(async () => {
-          content = await app.vault.read(file);
-          position = inline
-            ? await getInlineButtonPosition(app, id)
-            : getButtonPosition(content, args);
-          remove(app, args, position);
-        }, 75);
+        content = await app.vault.read(file);
+        position = inline
+          ? await getInlineButtonPosition(app, id)
+          : getButtonPosition(content, args);
+        await remove(app, args, position);
       }
       if (args.replace) {
-        replace(app, args);
+        await replace(app, args);
       }
     }
   });

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -263,50 +263,7 @@ export const templater = async (
     const content = await app.vault.cachedRead(file);
     await runTemplater(app);
     const { args } = await getNewArgs(app, position);
-    const cachedData: string[] = [];
-    const cacheChange = app.vault.on("modify", (file) => {
-      cachedData.push(file.unsafeCachedData);
-    });
-    setTimeout(async () => {
-      const button = content
-        .split("\n")
-        .splice(position.lineStart, position.lineEnd - position.lineStart + 2)
-        .join("\n");
-      let finalContent;
-      if (cachedData[0]) {
-        const cachedContent = cachedData[cachedData.length - 1].split("\n");
-        let addOne = false;
-        if (args.type.includes("prepend")) {
-          addOne = true;
-        } else if (args.type.includes("line")) {
-          const lineNumber = args.type.match(/(\d+)/g);
-          if (lineNumber[0]) {
-            const line = parseInt(lineNumber[0]) - 1;
-            if (line < position.lineStart && !args.replace) {
-              addOne = true;
-            }
-          }
-        }
-        if (addOne) {
-          cachedContent.splice(
-            position.lineStart + 1,
-            position.lineEnd - position.lineStart + 2,
-            button
-          );
-        }  else {
-          cachedContent.splice(
-            position.lineStart,
-            position.lineEnd - position.lineStart + 2,
-            button
-          );
-        }
-        finalContent = cachedContent.join("\n");
-      } else {
-        finalContent = content;
-      }
-      await app.vault.modify(file, finalContent);
-      app.metadataCache.offref(cacheChange);
-    }, 200);
+    await app.vault.modify(file, content);
     return args;
   }
 };

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -15,7 +15,7 @@ import {
   getInlineButtonPosition,
   findNumber,
 } from "./parser";
-import { handleValueArray, getNewArgs } from "./utils";
+import { handleValueArray, getNewArgs, runTemplater } from "./utils";
 import {
   getButtonSwapById,
   setButtonSwapById,
@@ -261,9 +261,7 @@ export const templater = async (
     await activeView.save();
     const file = activeView.file;
     const content = await app.vault.cachedRead(file);
-    app.commands.executeCommandById(
-      "templater-obsidian:replace-in-file-templater"
-    );
+    await runTemplater(app);
     const { args } = await getNewArgs(app, position);
     const cachedData: string[] = [];
     const cacheChange = app.vault.on("modify", (file) => {

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -256,9 +256,9 @@ export const templater = async (
   app: App,
   position: Position
 ): Promise<Arguments> => {
-  app.commands.executeCommandById("editor:save-file");
   const activeView = app.workspace.getActiveViewOfType(MarkdownView);
   if (activeView) {
+    await activeView.save();
     const file = activeView.file;
     const content = await app.vault.cachedRead(file);
     app.commands.executeCommandById(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,25 +92,20 @@ export const handleValueArray = (
   }
 };
 
-export function getNewArgs(
+export async function getNewArgs(
   app: App,
   position: Position
-): Promise<{ args: Arguments; content: string }> {
-  const promise = new Promise((resolve) => {
-    setTimeout(async () => {
-      const activeView = app.workspace.getActiveViewOfType(MarkdownView);
-      const newContent = await app.vault
-        .cachedRead(activeView.file)
-        .then((content: string) => content.split("\n"));
-      const newButton = newContent
-        .splice(position.lineStart, position.lineEnd - position.lineStart)
-        .join("\n")
-        .replace("```button", "")
-        .replace("```", "");
-      resolve({ args: createArgumentObject(newButton) });
-    }, 150);
-  });
-  return promise as Promise<{ args: Arguments; content: string }>;
+): Promise<{ args: Arguments }> {
+  const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+  const newContent = await app.vault
+    .cachedRead(activeView.file)
+    .then((content: string) => content.split("\n"));
+  const newButton = newContent
+    .splice(position.lineStart, position.lineEnd - position.lineStart)
+    .join("\n")
+    .replace("```button", "")
+    .replace("```", "");
+  return { args: createArgumentObject(newButton) };
 }
 
 export const wrapAround = (value: number, size: number): number => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,3 +116,25 @@ export function getNewArgs(
 export const wrapAround = (value: number, size: number): number => {
   return ((value % size) + size) % size;
 };
+
+/**
+ * Run Templater's "Replace templates in the active file" command and wait until complete.
+ */
+export const runTemplater = (
+  app: App
+): Promise<{
+  file: TFile;
+  content: string;
+}> =>
+  new Promise((resolve) => {
+    const ref = app.workspace.on(
+      "templater:overwrite-file",
+      (file: TFile, content: string) => {
+        app.workspace.offref(ref);
+        resolve({ file, content });
+      }
+    );
+    app.commands.executeCommandById(
+      "templater-obsidian:replace-in-file-templater"
+    );
+  });


### PR DESCRIPTION
This pull request speeds up button deletion by ~2 seconds when the `remove` option is used.  Removal of `setTimeout` calls also removes avenues for potential race conditions.

**Note:** this PR depends on #117, and may be easier to grok after #117 is merged.

I appreciate that you're working on a new version of Buttons but I think this fix might benefit others in the meantime if you would be willing to release it.