### PR TITLE
Inline button: fix on mobile

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -35,9 +35,12 @@ export const createButton = ({
 }: Button): HTMLElement => {
   //create the button element
   const button = el.createEl("button", {
-    cls: args.class
+    cls: [
+      args.class
       ? `${args.class} ${args.color}`
       : `button-default ${args.color ? args.color : ""}`,
+      inline ? "button-inline" : ""
+      ]
   });
   button.innerHTML = args.name;
   args.id ? button.setAttribute("id", args.id) : "";

--- a/src/button.ts
+++ b/src/button.ts
@@ -1,4 +1,4 @@
-import { App, Notice, MarkdownView} from "obsidian";
+import { App, Notice, MarkdownView } from "obsidian";
 import { Arguments } from "./types";
 import {
   calculate,

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,12 @@ button.button-default:hover {
   transform: translate3d(0px, -1.5px, 0px);
 }
 
+button.button-inline {
+  width: unset;
+  height: unset;
+  padding: 0 8px;
+}
+
 button.blue {
   background: #76b3fa;
   color: black;


### PR DESCRIPTION
Fixes #138  via adding `button-inline` class to an inline button.