### PR TITLE
Change the template insertion method.

### DIFF
--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -143,7 +143,7 @@ export const template = async (
         );
       }
       if (args.type.includes("note")) {
-        createNote(app, content, args.type);
+        createNote(app, content, args.type, file, args.templater);
       }
       if (args.type.includes("line")) {
         addContentAtLine(app, content, args.type);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -148,17 +148,26 @@ export const addContentAtLine = async (
 export const createNote = async (
   app: App,
   content: string,
-  type: string
+  type: string,
+  filePath?: TFile,
+  templater?: string
 ): Promise<void> => {
   const path = type.match(/\(([\s\S]*?),?\s?(split)?\)/);
   if (path) {
     try {
-      await app.vault.create(`${path[1]}.md`, content);
-      const file = app.vault.getAbstractFileByPath(`${path[1]}.md`) as TFile;
-      if (path[2]) {
-        await app.workspace.splitActiveLeaf().openFile(file);
+      if (filePath) {
+        await app.vault.create(`${path[1]}.md`, "");
       } else {
-        app.workspace.activeLeaf.openFile(file);
+        await app.vault.create(`${path[1]}.md`, content);
+      }
+      const file = await app.vault.getAbstractFileByPath(`${path[1]}.md`) as TFile;
+      await app.workspace.getLeaf().openFile(file);
+      if (filePath) {
+        if (templater) {
+          (app as any).plugins.plugins["templater-obsidian"].templater.append_template_to_active_file(filePath);
+        } else {
+          (app as any).internalPlugins?.plugins["templates"].instance.insertTemplate(filePath);
+        }
       }
     } catch (e) {
       new Notice("There was an error! Maybe the file already exists?", 2000);


### PR DESCRIPTION
When inserting a template, the method has been changed from pasting the content to calling the template(r) plugin function.

- This pull request fixes insertion template bugs like #114.
- it may also relate to #117.
- I was referring to [obsidian-hotkeys-for-templates](https://github.com/Vinzent03/obsidian-hotkeys-for-templates).