### PR TITLE
Add Prepend and Append logic to Command buttons

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -63,6 +63,7 @@ const clickHandler = async (
   let position = inline
     ? await getInlineButtonPosition(app, id)
     : getButtonPosition(content, args);
+    const buttonStart = getButtonPosition(content,args);
   // handle command buttons
   if (args.templater) {
     args = await templater(app, position);
@@ -73,8 +74,8 @@ const clickHandler = async (
   if (args.replace) {
     replace(app, args);
   }
-  if (args.type === "command") {
-    command(app, args);
+  if (args.type && args.type.includes("command")) {
+    command(app, args, buttonStart);
   }
   // handle link buttons
   if (args.type === "link") {

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -174,12 +174,23 @@ export const link = ({ action }: Arguments): void => {
   window.open(link);
 };
 
-export const command = (app: App, { action }: Arguments): void => {
+export const command = (app: App, args: Arguments, buttonStart): void => {
   const allCommands = app.commands.listCommands();
+  const action = args.action;
   const command = allCommands.filter(
     (command) => command.name.toUpperCase() === action.toUpperCase().trim()
   )[0];
-  app.commands.executeCommandById(command.id);
+  if (args.type.includes("prepend")) {
+    app.workspace.getActiveViewOfType(MarkdownView).editor.setCursor(buttonStart.lineStart,0);
+    app.commands.executeCommandById(command.id);
+  }
+  if (args.type.includes("append")) {
+    app.workspace.getActiveViewOfType(MarkdownView).editor.setCursor(buttonStart.lineEnd+2,0);
+    app.commands.executeCommandById(command.id);
+  }
+  if (args.type === "command") {
+    app.commands.executeCommandById(command.id);
+  }
 };
 
 export const swap = async (

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -137,6 +137,14 @@ export class ButtonModal extends Modal {
             new Setting(action)
               .setName("Command")
               .setDesc("Enter a command to run")
+              .addDropdown((drop) => {
+              drop.addOption("command", "Default");
+              drop.addOption("prepend command", "Prepend");
+              drop.addOption("apped command", "Append");
+              drop.onChange((value) => {
+                this.outputObject.type = value;
+              })
+              })
               .addText((textEl) => {
                 textEl.inputEl.replaceWith(this.commandSuggestEl);
               });


### PR DESCRIPTION
Enhancing command buttons to enable them to prepend or append command output (relative to the button).

This PR effectively resolves Issue #119 (https://github.com/shabegom/buttons/issues/119).
By assigning a template to a hotkey (a workaround proposed by ladyMonolid in the obsidian forum: https://forum.obsidian.md/t/buttons-with-templater-and-metaedit-trying-to-update-frontmatter-value-but-it-keeps-reverting/53384), command buttons can run a template.

Since this PR permits command buttons to now prepend or append content, it permits the same functionality of a prepend or append template button.