### PR TITLE
New Feature: Open new tab when creating new file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The quickest way to get started with Buttons is to use the Button Maker. You can
         - **Prepend Template:** Click the Button to prepend a template into the current note.
         - **Append Template:** Click the Button to append a template into the current note.
         - **Add Template at Line:** Click the Button to add a template into the current note at the specified line.
-        - **New Note From Template:** Choose the Template, write the name of the new note, choose whether the new note should open in a split pane.
+        - **New Note From Template:** Choose the Template, write the name of the new note, choose whether the new note should replace the existing tab, open a new tab or split pane.
     - **Text:** Choose Prepend, Append, New Note, or Line and the text you want to use:
         - **Prepend Template:** Click the Button to prepend text into the current note.
         - **Append Template:** Click the Button to append text into the current note.
@@ -228,7 +228,7 @@ Say you want the weather to appear at a specific place in your note that isn't d
     ^button-weatherLine
 
 #### New Note From Template
-Create a new note for an upcoming meeting based on a Meeting Note Template:
+Create a new note in a new split pane for an upcoming meeting based on a Meeting Note Template:
 
     ```button
     name New Meeting
@@ -237,11 +237,11 @@ Create a new note for an upcoming meeting based on a Meeting Note Template:
     ```
     ^button-meeting
 
-Dynamically add the hour and minute to the note title:
+Dynamically add the hour and minute to the note title and open as a new tab:
 
     ```button
     name New Meeting
-    type note(Meeting-<%tp.date.now("HH-MM") %>, split) note
+    type note(Meeting-<%tp.date.now("HH-MM") %>, tab) note
     action Meeting Note Template
     templater true
     ```

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -154,7 +154,7 @@ export const createNote = async (
   if (path) {
     try {
       await app.vault.create(`${path[1]}.md`, content);
-      const file = app.vault.getAbstractFileByPath(`${path[1]}.md`);
+      const file = app.vault.getAbstractFileByPath(`${path[1]}.md`) as TFile;
       if (path[2] == "split") {
         await app.workspace.splitActiveLeaf().openFile(file);
       } else if (path[2] == "tab") {
@@ -163,9 +163,9 @@ export const createNote = async (
         app.workspace.activeLeaf.openFile(file);
       }
     } catch (e) {
-      new obsidian.Notice("There was an error! Maybe the file already exists?", 2000);
+      new Notice("There was an error! Maybe the file already exists?", 2000);
     }
   } else {
-    new obsidian.Notice(`couldn't parse the path!`, 2000);
+    new Notice(`couldn't parse the path!`, 2000);
   }
 };

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -150,20 +150,22 @@ export const createNote = async (
   content: string,
   type: string
 ): Promise<void> => {
-  const path = type.match(/\(([\s\S]*?),?\s?(split)?\)/);
+  const path = type.match(/\(([\s\S]*?),?\s?(split|tab)?\)/);
   if (path) {
     try {
       await app.vault.create(`${path[1]}.md`, content);
-      const file = app.vault.getAbstractFileByPath(`${path[1]}.md`) as TFile;
-      if (path[2]) {
+      const file = app.vault.getAbstractFileByPath(`${path[1]}.md`);
+      if (path[2] == "split") {
         await app.workspace.splitActiveLeaf().openFile(file);
+      } else if (path[2] == "tab") {
+        await app.workspace.getLeaf(!0).openFile(file);
       } else {
         app.workspace.activeLeaf.openFile(file);
       }
     } catch (e) {
-      new Notice("There was an error! Maybe the file already exists?", 2000);
+      new obsidian.Notice("There was an error! Maybe the file already exists?", 2000);
     }
   } else {
-    new Notice(`couldn't parse the path!`, 2000);
+    new obsidian.Notice(`couldn't parse the path!`, 2000);
   }
 };


### PR DESCRIPTION
The split pane option was not something that I wanted, but it was the only option I had without closing the tab where the button currently exist, I've created a new tab option 

# New
`type note(10_Inbox/tab, tab) template`
New action to open up a new tab
![CleanShot 2023-05-03 at 19 09 34](https://user-images.githubusercontent.com/2829722/236096084-ad94968b-90f0-4216-a0c7-26ff5df11639.gif)

# Existing Actions
Default action when opening up a button with no "split" action
`type note(10_Inbox/default) template`
![CleanShot 2023-05-03 at 19 07 15](https://user-images.githubusercontent.com/2829722/236096015-5b69c533-b199-4f52-88f1-f8565a21a584.gif)

`type note(10_Inbox/split, split) template`
Existing action when adding "split" action
![CleanShot 2023-05-03 at 19 08 07](https://user-images.githubusercontent.com/2829722/236096063-07dbb593-1c28-42c9-94d8-708c5697be69.gif)
