### PR TITLE
Fixed remove in the modal (#97)

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -319,6 +319,7 @@ export class ButtonModal extends Modal {
                 .addText((textEl) => {
                   textEl.inputEl.replaceWith(this.removeSuggestEl);
                 });
+                this.outputObject.remove = value;
             }
             if (!value) {
               this.outputObject.remove = "";


### PR DESCRIPTION
fixed an issue where a button would not have the `remove` argument if it was not changed or focused in the create button modal.
I believe this fixes #97 