### PR TITLE
fix template search with folders having "/" prefixed

### DIFF
--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -105,7 +105,7 @@ export const template = async (
       templaterPluginEnabled && app.plugins?.plugins[
         "templater-obsidian"
       ]?.settings.templates_folder?.toLowerCase(),
-    ].filter((folder) => folder);
+    ].filter((folder) => folder).map((folder) => folder.replace(/^\//, ''));
     const templateFile = args.action.toLowerCase();
     const allFiles = app.vault.getFiles();
     const file: TFile = allFiles.filter((file) => {


### PR DESCRIPTION
Fixes [this issue](https://github.com/shabegom/buttons/issues/196), template search failing because of prefixed folder names from plugins. 