### PR TITLE
Create folder for new note if it doesn't exist

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -151,10 +151,19 @@ export const createNote = async (
   type: string
 ): Promise<void> => {
   const path = type.match(/\(([\s\S]*?),?\s?(split)?\)/);
+
   if (path) {
+    const fullPath = `${path[1]}.md`;
+    const directoryPath = fullPath.substring(0, fullPath.lastIndexOf('/'));
+
     try {
-      await app.vault.create(`${path[1]}.md`, content);
-      const file = app.vault.getAbstractFileByPath(`${path[1]}.md`) as TFile;
+      // Check if the directory exists, if not, create it
+      if (!app.vault.getAbstractFileByPath(directoryPath)) {
+        await app.vault.createFolder(directoryPath);
+      }
+
+      await app.vault.create(fullPath, content);
+      const file = app.vault.getAbstractFileByPath(fullPath) as TFile;
       if (path[2]) {
         await app.workspace.splitActiveLeaf().openFile(file);
       } else {


### PR DESCRIPTION
This creates the folder if the new note's path if it doesn't exist. Useful for organizing the children of a "parent" note template into their own folder using templater.

## Example Use-case
This button is in a recurring meeting note which hosts a bunch of "children" meeting notes
````
```button
name New Meeting
type note(Notes/Meetings/<%tp.file.title%>/<%tp.file.title%> <%tp.date.now()%> Meeting, split) template
action Meeting Template
templater true
```
````

Currently if the `<%tp.file.title%>` folder doesn't exist, it throws a "There was an error! Maybe the file already exists?" error. This PR changes the behavor by creating the folder when one doesn't exist.