### PR TITLE
adds hidden attribute to buttons, and copy type button

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -7,6 +7,7 @@ import {
   template,
   link,
   command,
+  copy,
   swap,
   templater,
   text,
@@ -75,6 +76,9 @@ const clickHandler = async (
   }
   if (args.type === "command") {
     command(app, args);
+  }
+  if (args.type === "copy") {
+    copy(args);
   }
   // handle link buttons
   if (args.type === "link") {

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -174,6 +174,11 @@ export const link = ({ action }: Arguments): void => {
   window.open(link);
 };
 
+// take the action and copy it to the clipboard
+export const copy = ({ action }: Arguments): void => {
+  navigator.clipboard.writeText(action);
+}
+
 export const command = (app: App, { action }: Arguments): void => {
   const allCommands = app.commands.listCommands();
   const command = allCommands.filter(

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,8 @@ export default class ButtonsPlugin extends Plugin {
         const storeArgs = await getButtonFromStore(this.app, args);
         args = storeArgs ? storeArgs.args : args;
         const id = storeArgs && storeArgs.id;
-        createButton({ app: this.app, el, args, inline: false, id });
+        if (Boolean(args['hidden']) !== true)
+          createButton({ app: this.app, el, args, inline: false, id });
       }
     );
 


### PR DESCRIPTION
# New Optional Button Argument: "Hidden"
## brief
Creates hidden buttons so that you can use inline buttons without cluttering the note with main button in arbitrary locations.
## use case
zotero integration plugin which overwrites the same note every time you sync with zotero, but there is no easy way to make a separate meta file to hold custom buttons per annotation.

# New Button Type: "Copy" 
## brief
Copies to clipboard & does not rely on templater
## use case
- When using templater with zotero integration plugin, the auto generation of the zotero file will trigger the templater commands and remove them from the buttons.
- When using Copy this does not happen.

````
```button
hidden true
name 📋
type copy
action some text to copy to clipboard
```
````
# Example
![image](https://github.com/shabegom/buttons/assets/14037388/3ded7db0-9d97-477a-8a3a-47f45e67a3d7)



