### PR TITLE
bugfix: default name for button

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -64,7 +64,7 @@ export class ButtonModal extends Modal {
   }
 
   private outputObject = {
-    name: "",
+    name: "My Awesome Button",
     type: "",
     action: "",
     swap: "",


### PR DESCRIPTION
Fixes #201 

Gives a button maker button a default name so it doesn't break some magical shit