### PR TITLE
Revert templater

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Run commands and open links by clicking on ✨ Buttons ✨
 
 ---
 
-**last updated:** February 1st, 2024
+**last updated:** February 9th, 2024
 
+0.5.1 - fixed all those templater issues
+
+0.5.0
 Holy shit, look at all these awesome people that helped improve Buttons!
 
 - Enhancement: Moved to more reliable templater processor ([shabegom])
@@ -331,15 +334,33 @@ Note: swap count is reset if you close the note.
 
 ## Releases
 
+### 0.5.1
+- Bugfix: Templater commands that move, rename, etc should be working again
+- The default templates plugin should be working again
+- sets a default name for a button so problems don't happen.
+
 ### 0.5.0
-
-
+- Enhancement: Moved to more reliable templater processor ([shabegom])
 - Bugfix: buttons now render in Live Preview mode when Obsidian starts ([Lx])
 - Bugfix: improve reliability of `templater` option ([Lx])
-- improve speed of `remove` option ([Lx])
+- Enhancement: improve speed of `remove` option ([Lx])
+- Feature: Add default folder and prompt for name settings ([unxok])
+- Features: Button type copy for "copy text to clipboard", and custom color for button background and tex ([rafa-carmo])
+- Feature: adds hidden attribute to buttons ([Liimurr])
+- Enhancement: Create folder for new note if it doesn't exist ([SabriDW])
+- Bugfix: fix template search with folders having "/" prefixed ([Balake])
+- Feature: Open new tab when creating new file ([0snug0])
+- Update Readme: new note from template ([antulik])
 
 
 [Lx]: https://github.com/Lx
+[unxok]: https://github.com/unxok
+[rafa-carmo]: https://github.com/rafa-carmo
+[Liimurr]: https://github.com/Liimurr
+[SabriDW]: https://github.com/SabriDW
+[Balake]: https://github.com/Balake
+[0snug0]: https://github.com/0snug0 
+[antulik]: https://github.com/antulik
 
 
 ### 0.4.4

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "buttons",
   "name": "Buttons",
   "description": "Create Buttons in your Obsidian notes to run commands, open links, and insert templates",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "shabegom",
   "authorUrl": "https://shbgm.ca",
   "isDesktopOnly": false,

--- a/src/button.ts
+++ b/src/button.ts
@@ -9,7 +9,6 @@ import {
   replace,
   swap,
   template,
-  templater,
   text,
 } from "./buttonTypes";
 import { getButtonPosition, getInlineButtonPosition } from "./parser";

--- a/src/button.ts
+++ b/src/button.ts
@@ -4,7 +4,6 @@ import {
   calculate,
   command,
   copy,
-  copyText,
   link,
   remove,
   replace,
@@ -92,10 +91,6 @@ const clickHandler = async (
   // handle link buttons
   if (args.type === "link") {
     link(args);
-  }
-  // handle copy text buttons
-  if (args.type === "copy") {
-    copyText(args);
   }
   // handle template buttons
   if (args.type && args.type.includes("template")) {

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -76,17 +76,17 @@ export const text = async (
 ): Promise<void> => {
   // prepend template above the button
   if (args.type.includes("prepend")) {
-    await prependContent(app, args.action, position.lineStart);
+    await prependContent(app, args.action, position.lineStart, false);
   }
   // append template below the button
   if (args.type.includes("append")) {
-    await appendContent(app, args.action, position.lineEnd);
+    await appendContent(app, args.action, position.lineEnd, false);
   }
   if (args.type.includes("note")) {
     createNote(app, args.type, args.folder, args.prompt, args.action, false);
   }
   if (args.type.includes("line")) {
-    await addContentAtLine(app, args.action, args.type);
+    await addContentAtLine(app, args.action, args.type, false);
   }
 };
 
@@ -137,26 +137,17 @@ export const template = async (
     if (file) {
       // prepend template above the button
       if (args.type.includes("prepend")) {
-      const processTemplate = await createTemplater(file)
-      const templateContent = await app.vault.read(file)
-      const content = await processTemplate(templateContent)
-        await prependContent(app, content, position.lineStart);
+        await prependContent(app, file, position.lineStart, isTemplater);
       }
       // append template below the button
       if (args.type.includes("append")) {
-      const processTemplate = await createTemplater(file)
-      const templateContent = await app.vault.read(file)
-      const content = await processTemplate(templateContent)
-        await appendContent(app, content, position.lineEnd);
+        await appendContent(app, file, position.lineEnd, isTemplater);
       }
       if (args.type.includes("note")) {
         createNote(app, args.type, args.folder, args.prompt, file, isTemplater);
       }
       if (args.type.includes("line")) {
-      const processTemplate = await createTemplater(file)
-      const templateContent = await app.vault.read(file)
-      const content = await processTemplate(templateContent)
-        await addContentAtLine(app, content, args.type);
+        await addContentAtLine(app, file, args.type, isTemplater);
       }
     } else {
       new Notice(

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -131,7 +131,7 @@ export const template = async (
         await appendContent(app, content, position.lineEnd);
       }
       if (args.type.includes("note")) {
-        createNote(app, content, args.type, args.folder, args.prompt, file, args.templater);
+        createNote(app, content, args.type, args.folder, args.prompt, file);
       }
       if (args.type.includes("line")) {
         await addContentAtLine(app, content, args.type);

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -303,7 +303,3 @@ export const templater = async (
   }
 };
 
-export const copyText = ({ action }: Arguments): void => {
-  navigator.clipboard.writeText(action);
-  new Notice('Text Copied!');
-}

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -131,7 +131,7 @@ export const template = async (
         await appendContent(app, content, position.lineEnd);
       }
       if (args.type.includes("note")) {
-        createNote(app, args.type, args.folder, args.prompt, file, args.templater);
+        createNote(app, args.type, args.folder, args.prompt, file);
       }
       if (args.type.includes("line")) {
         await addContentAtLine(app, content, args.type);

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -131,7 +131,7 @@ export const template = async (
         await appendContent(app, content, position.lineEnd);
       }
       if (args.type.includes("note")) {
-        createNote(app, content, args.type, args.folder, args.prompt, file);
+        createNote(app, args.type, args.folder, args.prompt, file, args.templater);
       }
       if (args.type.includes("line")) {
         await addContentAtLine(app, content, args.type);

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -21,7 +21,7 @@ import {
   setButtonSwapById,
   getButtonById,
 } from "./buttonStore";
-import { processTemplate } from "./templater"
+import createTemplater from "./templater"
 
 export const calculate = async (
   app: App,
@@ -83,7 +83,7 @@ export const text = async (
     await appendContent(app, args.action, position.lineEnd);
   }
   if (args.type.includes("note")) {
-    createNote(app, args.action, args.type, args.folder, args.prompt);
+    createNote(app, args.type, args.folder, args.prompt, args.action, false);
   }
   if (args.type.includes("line")) {
     await addContentAtLine(app, args.action, args.type);
@@ -104,7 +104,6 @@ export const template = async (
 
   if (templatesEnabled || templaterPluginEnabled) {
   if (templatesEnabled) {
-      console.log("searching internal templates plugin folder")
     const folder: string = 
       templatesEnabled &&
         app.internalPlugins.plugins.templates.instance.options.folder?.toLowerCase()
@@ -119,7 +118,6 @@ export const template = async (
   }
 
   if (!file && templaterPluginEnabled) {
-    console.log('searching templater folder')
     const folder: string = 
       templaterPluginEnabled &&
         app.plugins?.plugins[
@@ -139,20 +137,25 @@ export const template = async (
     if (file) {
       // prepend template above the button
       if (args.type.includes("prepend")) {
-      const content = await processTemplate(file)
+      const processTemplate = await createTemplater(file)
+      const templateContent = await app.vault.read(file)
+      const content = await processTemplate(templateContent)
         await prependContent(app, content, position.lineStart);
       }
       // append template below the button
       if (args.type.includes("append")) {
-      const content = await processTemplate(file)
+      const processTemplate = await createTemplater(file)
+      const templateContent = await app.vault.read(file)
+      const content = await processTemplate(templateContent)
         await appendContent(app, content, position.lineEnd);
       }
       if (args.type.includes("note")) {
-        console.log(isTemplater)
         createNote(app, args.type, args.folder, args.prompt, file, isTemplater);
       }
       if (args.type.includes("line")) {
-      const content = await processTemplate(file)
+      const processTemplate = await createTemplater(file)
+      const templateContent = await app.vault.read(file)
+      const content = await processTemplate(templateContent)
         await addContentAtLine(app, content, args.type);
       }
     } else {

--- a/src/buttonTypes.ts
+++ b/src/buttonTypes.ts
@@ -21,7 +21,7 @@ import {
   setButtonSwapById,
   getButtonById,
 } from "./buttonStore";
-import createTemplater from "./templater"
+import {processTemplate} from "./templater"
 
 export const calculate = async (
   app: App,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -93,12 +93,12 @@ export const prependContent = async (
       contentArray.splice(lineStart, 0, `${insert}`);
     } else {
       if (isTemplater) {
-        const runTemplater = await templater(insert);
+        const runTemplater = await templater(insert, file);
         const content = await app.vault.read(insert);
         const processed = await runTemplater(content);
         contentArray.splice(lineStart, 0, `${processed}`);
       } else {
-        app.workspace.getActiveFileView().editor.setCursor(lineStart)
+        activeView.editor.setCursor(lineStart)
         await (app as any).internalPlugins?.plugins["templates"].instance
           .insertTemplate(insert);
       }
@@ -134,12 +134,12 @@ export const appendContent = async (
       contentArray.splice(insertionPoint, 0, `\n${insert}`);
     } else {
       if (isTemplater) {
-        const runTemplater = await templater(insert);
+        const runTemplater = await templater(insert, file);
         const content = await app.vault.read(insert);
         const processed = await runTemplater(content);
         contentArray.splice(insertionPoint, 0, `${processed}`);
       } else {
-        app.workspace.getActiveFileView().editor.setCursor(insertionPoint)
+        activeView.editor.setCursor(insertionPoint)
         await (app as any).internalPlugins?.plugins["templates"].instance
           .insertTemplate(insert);
       }
@@ -169,12 +169,12 @@ export const addContentAtLine = async (
         contentArray.splice(insertionPoint, 0, `${insert}`);
       } else {
         if (isTemplater) {
-          const runTemplater = await templater(insert);
+          const runTemplater = await templater(insert, file);
           const content = await app.vault.read(insert);
           const processed = await runTemplater(content);
           contentArray.splice(insertionPoint, 0, `${processed}`);
         } else {
-        app.workspace.getActiveFileView().editor.setCursor(insertionPoint)
+        activeView.editor.setCursor(insertionPoint)
           await (app as any).internalPlugins?.plugins["templates"].instance
             .insertTemplate(insert);
         }
@@ -227,11 +227,12 @@ export const createNote = async (
         file = await app.vault.create(fullPath, filePath);
       }
 
+
       const templateContent = await app.vault.read(filePath as TFile);
       if (isTemplater) {
         file = await app.vault.create(fullPath, templateContent);
-        const runTemplater = await templater(file);
-        const content = await app.vault.read(file);
+        const runTemplater = await templater(filePath, file);
+        const content = await app.vault.read(filePath);
         const processed = await runTemplater(content);
         await app.vault.modify(file, processed);
       }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -152,6 +152,7 @@ export const createNote = async (
   folder: string,
   prompt: string,
   filePath: TFile,
+  templater?: string
 ): Promise<void> => {
   const path = type.match(/\(([\s\S]*?),?\s?(split|tab)?\)/);
 
@@ -180,13 +181,22 @@ export const createNote = async (
           : fullPath;
       }
 
+      //first we create the file and put the template into it
       if (filePath) {
         const templateContent = await app.vault.read(filePath)
         await app.vault.create(fullPath, templateContent);
       }
 
+      //get the TFile
       const file = app.vault.getAbstractFileByPath(fullPath) as TFile;
+
+      //run templater or built in templates plugin
+      if (filePath && templater) {
       processTemplate(file)
+      } else if (filePath && !templater) {
+          (app as any).internalPlugins?.plugins["templates"].instance
+            .insertTemplate(filePath);
+      }
 
       if (path[2] === "split") {
         await app.workspace.splitActiveLeaf().openFile(file);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -151,7 +151,7 @@ export const createNote = async (
   type: string,
   folder: string,
   prompt: string,
-  filePath: TFile,
+  filePath: TFile | string,
   isTemplater?: boolean,
 ): Promise<void> => {
   const path = type.match(/\(([\s\S]*?),?\s?(split|tab)?\)/);
@@ -182,7 +182,11 @@ export const createNote = async (
       }
       let file: TFile;
 
-      const templateContent = await app.vault.read(filePath);
+      if (typeof filePath === "string") {
+        file = await app.vault.create(fullPath, filePath)
+      }
+
+      const templateContent = await app.vault.read(filePath as TFile);
       if (isTemplater) {
        file = await app.vault.create(fullPath, templateContent);
         const runTemplater = await templater(file);
@@ -190,7 +194,7 @@ export const createNote = async (
         const processed = await runTemplater(content);
         await app.vault.modify(file, processed);
       }
-      if (!isTemplater) {
+      if (!isTemplater && typeof filePath !== "string") {
         file = await app.vault.create(fullPath, "")
       }
 
@@ -201,7 +205,7 @@ export const createNote = async (
       } else {
         await app.workspace.getLeaf().openFile(file);
       }
-      if (!isTemplater) {
+      if (!isTemplater && typeof filePath !== "string") {
          await (app as any).internalPlugins?.plugins["templates"].instance.insertTemplate(filePath);
       }
     } catch (e) {

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -233,7 +233,7 @@ export class TemplateSuggest extends TextInputSuggest<TFile> {
         folders.push(folder.toLowerCase());
       }
       if (this.templaterPlugin) {
-        const folder = this.templaterPlugin.settings.template_folder;
+        const folder = this.templaterPlugin.settings.templates_folder;
         if (folder) {
           folders.push(folder.toLowerCase());
         }

--- a/src/templater.ts
+++ b/src/templater.ts
@@ -9,6 +9,7 @@ interface Item {
 
 async function templater(file?: TFile): Promise<RunTemplater | undefined> {
   const activeFile = file ? file : app.workspace.getActiveFile();
+  console.log(activeFile)
   const config = {
     template_file: activeFile,
     active_file: activeFile,

--- a/src/templater.ts
+++ b/src/templater.ts
@@ -5,15 +5,17 @@ type RunTemplater = (command: string) => Promise<string>;
 interface Item {
   name: string;
   static_functions: Array<[string, () => unknown]>;
+  dynamic_functions: Array<[string, () => unknown]>;
 }
 
-async function templater(file?: TFile): Promise<RunTemplater | undefined> {
-  const activeFile = file ? file : app.workspace.getActiveFile();
-  console.log(activeFile)
+async function templater(
+  template: TFile,
+  target: TFile,
+): Promise<RunTemplater | undefined> {
   const config = {
-    template_file: activeFile,
-    active_file: activeFile,
-    target_file: activeFile,
+    template_file: template,
+    active_file: app.workspace.getActiveFile(),
+    target_file: target,
     run_mode: "DynamicProcessor",
   };
   const plugins = app.plugins.plugins;
@@ -25,30 +27,24 @@ async function templater(file?: TFile): Promise<RunTemplater | undefined> {
   // eslint-disable-next-line
   // @ts-ignore
   const { templater } = plugins["templater-obsidian"];
-  const internalModuleArray =
-    templater.functions_generator.internal_functions.modules_array;
-  const functions = internalModuleArray.reduce(
-    (acc: Record<string, unknown>, item: Item) => {
-      acc[item.name] = Object.fromEntries(item.static_functions);
-      return acc;
-    },
-    {}
-  );
+  const functions = await templater.functions_generator.internal_functions.generate_object(config)
+
   functions.user = {};
-  const userScriptFunctions =
-    await templater.functions_generator.user_functions.user_script_functions.generate_user_script_functions();
+  const userScriptFunctions = await templater.functions_generator.user_functions
+    .user_script_functions.generate_user_script_functions(config);
   userScriptFunctions.forEach((value: () => unknown, key: string) => {
     functions.user[key] = value;
   });
-  if (activeFile) {
-    const userSystemFunctions =
-      await templater.functions_generator.user_functions.user_system_functions.generate_system_functions(
-        config
+  if (template) {
+    const userSystemFunctions = await templater.functions_generator
+      .user_functions.user_system_functions.generate_system_functions(
+        config,
       );
     userSystemFunctions.forEach((value: () => unknown, key: string) => {
       functions.user[key] = value;
     });
   }
+  console.log(functions);
   return async (command: string) => {
     return await templater.parser.parse_commands(command, functions);
   };
@@ -57,7 +53,7 @@ async function templater(file?: TFile): Promise<RunTemplater | undefined> {
 export async function processTemplate(file: TFile) {
   try {
     const content = await app.vault.read(file);
-    const runTemplater = await templater(file);
+    const runTemplater = await templater(file, file);
     if (runTemplater) {
       const processed = await runTemplater(content);
       return processed;

--- a/src/templater.ts
+++ b/src/templater.ts
@@ -44,7 +44,6 @@ async function templater(
       functions.user[key] = value;
     });
   }
-  console.log(functions);
   return async (command: string) => {
     return await templater.parser.parse_commands(command, functions);
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,5 @@ export interface Position {
   lineStart: number;
   lineEnd: number;
 }
+
+


### PR DESCRIPTION
fix all those template issues.

- new notes should now process templater commands within the newly generated note
- tp.file.title works
- if you really want to use the built in templates plugin, it should work (this is a PITA and I encourage everyone to move to templater)

Fixes: #207 , #209 ,  #210 