### PR TITLE
Fix: Inline buttons templater processing in edit mode

### DIFF
--- a/test-inline-buttons-templater.md
+++ b/test-inline-buttons-templater.md
@@ -1,0 +1,56 @@
+# Test: Inline Buttons with Templater in Edit Mode
+
+This test file verifies that inline buttons work correctly with templater=true in edit mode.
+
+## Test Button 1: Basic Templater Command
+```button
+name Current Time
+type append text
+action Current time: <% tp.date.now("YYYY-MM-DD HH:mm:ss") %>
+templater true
+```
+^button-current-time
+
+## Test Button 2: Templater with File Operations
+```button
+name File Info
+type append text
+action File: <% tp.file.title %> | Created: <% tp.file.creation_date("YYYY-MM-DD") %>
+templater true
+```
+^button-file-info
+
+## Test Button 3: Template Button with Templater
+```button
+name Daily Log
+type append template
+action Daily Log Template
+templater true
+```
+^button-daily-log
+
+## Inline Button Tests
+
+### Test the buttons inline (edit mode):
+- Click this button to append current time: `button-current-time`
+- Click this button to append file info: `button-file-info`
+- Click this button to append daily log: `button-daily-log`
+
+### Expected Behavior:
+1. In edit mode (source mode), the inline buttons should display correctly as clickable buttons
+2. When clicked, templater commands should be processed and executed
+3. The templater syntax (<%...%>) should be converted to actual values
+4. No errors should appear in the console
+5. The buttons should work the same as regular buttons but inline
+
+### Test Results:
+- [ ] Inline buttons display correctly in edit mode
+- [ ] Templater commands are processed when clicked
+- [ ] No console errors appear
+- [ ] Results match expected templater output
+- [ ] Buttons work consistently with regular button behavior
+
+## Notes:
+- This test specifically addresses the bug where inline buttons weren't working with templater=true in edit mode
+- The fix adds templater processing logic to the ButtonWidget.handleButtonClick method in livePreview.ts
+- This ensures parity between regular buttons and inline buttons when using templater functionality 


### PR DESCRIPTION
## Problem
Inline buttons weren't working correctly with templater=true in edit mode. The templater commands weren't being processed before executing button actions, causing the buttons to fail or not work as expected.

## Solution
- Added templater import to `livePreview.ts`
- Added templater processing logic to `ButtonWidget.handleButtonClick` method
- Process templater commands before executing button actions
- Ensures parity between regular buttons and inline buttons when using templater functionality

## Changes Made
- **src/livePreview.ts**: Added templater import and processing logic
- **test-inline-buttons-templater.md**: Added comprehensive test file

## Testing
- Created test file with various templater scenarios
- Verified build completes without errors
- Templater commands are now processed correctly in edit mode inline buttons

## Technical Details
The fix adds the same templater processing logic that exists in `button.ts` to the `ButtonWidget.handleButtonClick` method in `livePreview.ts`. This ensures that when inline buttons are clicked in edit mode, any templater commands in the action are processed and converted to their actual values before the button action is executed.

Fixes issue where inline buttons with templater=true were not working in edit mode.