### PR TITLE
feat: Add cursor-based replace mutation functionality

### DIFF
--- a/docs/content/pages/replace.md
+++ b/docs/content/pages/replace.md
@@ -76,6 +76,35 @@ replace [+1, 15]
 
 This removes from 1 line after the button to absolute line 15.
 
+### Cursor-Based Positioning
+Use `replace [cursor]` to remove the line at the current cursor position:
+
+<pre>
+Line 1: Keep this line
+Line 2: This line will be removed when cursor is here
+Line 3: Keep this line
+
+```button
+name Remove Line at Cursor
+type append text
+action Content updated!
+replace [cursor]
+```
+^button-cursor-remove
+</pre>
+
+**How cursor positioning works:**
+- Place your cursor anywhere on the line you want to remove
+- When the button is clicked, it will remove the line where your cursor is positioned
+- Perfect for interactive editing where you want to target specific lines dynamically
+- Works regardless of where the button is located in the document
+
+**Cursor positioning benefits:**
+- Interactive content removal based on cursor position
+- No need to count line numbers manually
+- Ideal for ad-hoc editing workflows
+- Perfect for removing specific lines without knowing their exact position
+
 ## Replace with Template Buttons
 
 ### Update Weather Section (Absolute)
@@ -277,6 +306,12 @@ templater true
 - Creating portable templates that work in multiple locations
 - The button might be moved around in the document
 - You want content replacement to stay relative to the button
+
+**Use Cursor Positioning (`replace [cursor]`) when:**
+- You want interactive, dynamic line removal based on where your cursor is
+- Working with ad-hoc editing workflows where line numbers aren't predictable
+- Creating utilities for content cleanup where users select lines by cursor position
+- Building editing tools that respond to user cursor placement
 
 ### Planning Your Replace Strategy
 - **Identify stable sections**: Replace content that changes regularly

--- a/src/handlers/removeSection.ts
+++ b/src/handlers/removeSection.ts
@@ -1,4 +1,4 @@
-import { App } from "obsidian";
+import { App, MarkdownView } from "obsidian";
 import { createContentArray } from "../utils";
 import { Position } from "../types";
 
@@ -11,6 +11,24 @@ export const removeSection = async (
   if (section.includes("[") && section.includes("]")) {
     const args = section.match(/\[(.*)\]/);
     if (args && args[1]) {
+      // Handle special [cursor] syntax
+      if (args[1].trim().toLowerCase() === "cursor") {
+        const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+        if (activeView) {
+          const editor = activeView.editor;
+          const cursor = editor.getCursor();
+          const cursorLine = cursor.line; // 0-based line number from editor
+          
+          // Remove the line at cursor position
+          if (cursorLine >= 0 && cursorLine < contentArray.length) {
+            contentArray.splice(cursorLine, 1);
+            const content = contentArray.join("\n");
+            await app.vault.modify(file, content);
+          }
+        }
+        return;
+      }
+      
       const argArray = args[1].split(/,\s?/);
       if (argArray[0]) {
         let startLine: number; // This will be 1-based line number

--- a/test-cursor-replace.md
+++ b/test-cursor-replace.md
@@ -1,0 +1,26 @@
+# Test Cursor Replace Functionality
+
+Here's a test of the new `replace [cursor]` feature:
+
+Line 1: Keep this line
+Line 2: Place cursor here and click the button to remove this line
+Line 3: This line should also stay
+Line 4: Another line that could be removed if cursor is placed here
+Line 5: Final line to keep
+
+```button
+name Remove Line at Cursor
+type append text
+action ✅ Line removed successfully!
+replace [cursor]
+```
+^button-test-cursor
+
+## Instructions
+
+1. Place your cursor anywhere on one of the lines above
+2. Click the "Remove Line at Cursor" button
+3. The line where your cursor was positioned should be removed
+4. The success message will be appended to the end of the file
+
+This demonstrates the new `[cursor]` argument for the replace mutation which allows for interactive line removal based on cursor position. 


### PR DESCRIPTION
## Summary

This PR implements the requested cursor-based replace mutation functionality, allowing users to use `replace [cursor]` to remove content at the current cursor position.

## Changes Made

### Core Implementation
- **Modified `src/handlers/removeSection.ts`**: Added support for detecting `[cursor]` syntax and removing the line at the current cursor position
- **Import `MarkdownView`**: Added necessary import to access the editor and cursor position

### Documentation
- **Updated `docs/content/pages/replace.md`**: Added comprehensive documentation section on cursor-based positioning
- **Added examples**: Included practical examples showing how to use `[cursor]` syntax
- **Updated best practices**: Added guidance on when to use cursor positioning vs other methods

### Testing
- **Created `test-cursor-replace.md`**: Added demonstration file showing the new functionality in action

## How It Works

1. When a button with `replace [cursor]` is clicked
2. The system detects the special `cursor` keyword
3. Gets the current cursor position from the active MarkdownView editor
4. Removes the line at that cursor position
5. Updates the file content

## Benefits

- **Interactive editing**: Users can target specific lines by cursor placement
- **Dynamic workflows**: No need to count line numbers manually  
- **Ad-hoc content management**: Perfect for cleanup and editing tasks
- **User-friendly**: Intuitive cursor-based interaction

## Backward Compatibility

This change is fully backward compatible - existing replace functionality with line numbers and relative positioning continues to work exactly as before.

## Example Usage

```markdown
Line 1: Keep this
Line 2: Remove this by placing cursor here
Line 3: Keep this too

```button
name Remove Current Line
type append text
action Content updated!
replace [cursor]
```
```

Fixes the user's request for cursor-based replace mutation functionality.