### PR TITLE
Fix: Pass Component to MarkdownRenderer.render to prevent memory leaks

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownView, Notice, MarkdownRenderer } from "obsidian";
+import { App, MarkdownView, Notice, MarkdownRenderer, Component } from "obsidian";
 import { Arguments } from "./types";
 import {
   calculate,
@@ -21,6 +21,7 @@ export interface Button {
   args?: Arguments;
   inline?: boolean;
   id?: string;
+  component?: Component;
   clickOverride?: {
     params: unknown[];
     click: (...params: unknown[]) => void;
@@ -33,6 +34,7 @@ export const createButton = ({
   args,
   inline,
   id,
+  component,
   clickOverride,
 }: Button): HTMLElement => {
   //create the button element
@@ -57,7 +59,7 @@ export const createButton = ({
     args.name,
     button,
     app.workspace.getActiveFile()?.path || "",
-    null
+    component
   );
 
   // Changing the button's innerHTML to be wrapped in a div rather than a p so that it is not on a new line

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   Events,
   MarkdownRenderChild,
   Plugin,
+  Component,
 } from "obsidian";
 import { createArgumentObject } from "./utils";
 import {
@@ -96,8 +97,11 @@ export default class ButtonsPlugin extends Plugin {
         const storeArgs = await getButtonFromStore(this.app, args);
         args = storeArgs ? storeArgs.args : args;
         const id = storeArgs && storeArgs.id;
-        if (Boolean(args['hidden']) !== true)
-          createButton({ app: this.app, el, args, inline: false, id });
+        if (Boolean(args['hidden']) !== true) {
+          // Create a component for managing button lifecycle
+          const component = new Component();
+          createButton({ app: this.app, el, args, inline: false, id, component });
+        }
       }
     );
 
@@ -154,6 +158,7 @@ class InlineButton extends MarkdownRenderChild {
       args: this.args,
       inline: true,
       id: this.id,
+      component: this,
     });
     this.el.replaceWith(button);
   }

--- a/src/livePreview.ts
+++ b/src/livePreview.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownView, Notice, MarkdownRenderer } from "obsidian";
+import { App, MarkdownView, Notice, MarkdownRenderer, Component } from "obsidian";
 import {
   Decoration,
   DecorationSet,
@@ -98,6 +98,8 @@ function buttonPlugin(app: App) {
 }
 
 class ButtonWidget extends WidgetType {
+  private component: Component;
+
   constructor(
     readonly el: HTMLElement,
     readonly id: string,
@@ -105,10 +107,16 @@ class ButtonWidget extends WidgetType {
     readonly line: number
   ) {
     super();
+    this.component = new Component();
   }
 
   eq(other: ButtonWidget): boolean {
     return other.id === this.id;
+  }
+
+  destroy() {
+    // Clean up the component to prevent memory leaks
+    this.component.unload();
   }
 
   toDOM(): HTMLElement {
@@ -138,7 +146,7 @@ class ButtonWidget extends WidgetType {
           args.name,
           this.el,
           this.app.workspace.getActiveFile()?.path || "",
-          null
+          this.component
         );
       
         // Changing the button's innerHTML to be wrapped in a div rather than a p so that it is not on a new line

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -359,6 +359,7 @@ export class ButtonModal extends Modal {
       app: this.app,
       el: previewContainer,
       args: { name: "My Awesome Button" },
+      component: null, // Preview button doesn't need component lifecycle management
     });
   }
 


### PR DESCRIPTION
Fixes the bug where buttons were not passing Component in renderMarkdown, which is needed to avoid memory leaks when embedded contents register global event handlers.

The error was occurring because MarkdownRenderer.render() was being called with null for the Component parameter. This Component parameter is required for Obsidian to properly manage the lifecycle of any global event handlers.

Changes:
- Added Component imports and updated Button interface
- Fixed MarkdownRenderer.render calls to pass Component instead of null  
- Enhanced ButtonWidget class with proper Component lifecycle management
- Updated all createButton call sites to pass appropriate Component context

This ensures proper memory management and prevents the reported error.