### PR TITLE
Fix templater execution timing for code block buttons

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -129,8 +129,8 @@ const clickHandler = async (
     ? await getInlineButtonPosition(app, id)
     : getButtonPosition(content, args);
   
-  // Process templater commands for inline buttons only
-  if (inline && args.templater && args.action && args.action.includes("<%")) {
+  // Process templater commands for all buttons with templater true
+  if (args.templater && args.action && args.action.includes("<%")) {
     try {
       // Both template and target are activeFile since we're processing templater commands within the same file
       const runTemplater = await templater(app, activeFile, activeFile);
@@ -138,8 +138,8 @@ const clickHandler = async (
         args.action = await runTemplater(args.action);
       }
     } catch (error) {
-      console.error('Error processing templater in inline button:', error);
-      new Notice("Error processing templater in inline button. Check console for details.", 2000);
+      console.error('Error processing templater in button:', error);
+      new Notice("Error processing templater in button. Check console for details.", 2000);
     }
   }
   

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import { ButtonModal, InlineButtonModal } from "./modal";
 import { Button, createButton } from "./button";
 import buttonPlugin from "./livePreview";
 // import { updateWarning } from "./version";
-import templater from "./templater"
 
 export default class ButtonsPlugin extends Plugin {
   private buttonEvents: EventRef;
@@ -79,18 +78,7 @@ export default class ButtonsPlugin extends Plugin {
           .getFiles()
           .find((f) => f.path === ctx.sourcePath);
         
-        if (source.includes("<%") && file) {
-          try {
-            const runTemplater = await templater(this.app, file, file);
-            if (runTemplater) {
-              source = await runTemplater(source);
-            }
-          } catch (error) {
-            console.error('Error processing templater in button:', error);
-            // Continue with original source if templater fails
-          }
-        }
-        
+
         addButtonToStore(this.app, file);
         let args = createArgumentObject(source);
         const storeArgs = await getButtonFromStore(this.app, args);

--- a/src/livePreview.ts
+++ b/src/livePreview.ts
@@ -216,7 +216,7 @@ class ButtonWidget extends WidgetType {
       return;
     }
     
-    // Process templater commands for inline buttons only
+    // Process templater commands for all buttons with templater true
     if (args.templater && args.action && args.action.includes("<%")) {
       try {
         // Both template and target are activeFile since we're processing templater commands within the same file
@@ -225,8 +225,8 @@ class ButtonWidget extends WidgetType {
           args.action = await runTemplater(args.action);
         }
       } catch (error) {
-        console.error('Error processing templater in inline button:', error);
-        new Notice("Error processing templater in inline button. Check console for details.", 2000);
+        console.error('Error processing templater in button:', error);
+        new Notice("Error processing templater in button. Check console for details.", 2000);
       }
     }
     


### PR DESCRIPTION
## Problem

Fixes a bug reported on Discord where templater scripts inside append text buttons with timestamps fail to update with the actual time. The templater scripts were being executed at button creation/parse time instead of at button click time, causing time-sensitive commands like `tp.date.now()` to be "frozen" at the time the button was created.

## Root Cause

There was an inconsistency in when templater scripts are processed:

1. **Code block buttons**: Templater processing happened during parse time (when the button is rendered) in `src/index.ts`, not when clicked ❌
2. **Inline buttons**: Templater processing happened during click time in the button handlers ✅

## Solution

1. **Removed** parse-time templater processing from `src/index.ts` (lines 82-92)
2. **Updated** click-time templater processing in `src/button.ts` to work for all buttons, not just inline ones
3. **Updated** error messages to be generic instead of "inline button" specific
4. **Removed** unused templater import from `src/index.ts`

## Changes

- `src/index.ts`: Removed parse-time templater processing and unused import
- `src/button.ts`: Removed inline-only restriction for templater processing

## Testing

- ✅ Project builds successfully with no TypeScript errors
- ✅ No new linting errors introduced
- ✅ Templater commands now execute at click time for all button types

## Impact

This ensures that templater scripts like `<% tp.date.now("HH:mm:ss") %>` will execute fresh on each button click, providing the current time instead of the time when the button was created.

Resolves Discord bug report about templater scripts not updating on button click.