### PR TITLE
Fix issue #276: Process templater expressions in note titles

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -133,12 +133,22 @@ const clickHandler = async (
   
   // Process templater commands for all buttons with templater true
   let processedAction = args.action;
-  if (args.templater && args.action && args.action.includes("<%")) {
+  let processedType = args.type;
+  
+  if (args.templater) {
     try {
       // Both template and target are activeFile since we're processing templater commands within the same file
       const runTemplater = await templater(app, activeFile, activeFile);
       if (runTemplater) {
-        processedAction = await runTemplater(args.action);
+        // Process action field if it contains templater expressions
+        if (args.action && args.action.includes("<%")) {
+          processedAction = await runTemplater(args.action);
+        }
+        
+        // Process type field if it contains templater expressions (for note titles)
+        if (args.type && args.type.includes("<%")) {
+          processedType = await runTemplater(args.type);
+        }
       }
     } catch (error) {
       console.error('Error processing templater in button:', error);
@@ -146,8 +156,8 @@ const clickHandler = async (
     }
   }
 
-  // Create a copy of args with the processed action to avoid mutating the original
-  const processedArgs = { ...args, action: processedAction };
+  // Create a copy of args with the processed values to avoid mutating the original
+  const processedArgs = { ...args, action: processedAction, type: processedType };
   
   if (args.replace) {
     replace(app, processedArgs, position);

--- a/src/buttonTypes/chain.ts
+++ b/src/buttonTypes/chain.ts
@@ -29,13 +29,23 @@ export const chain = async (
       
       // Process templater commands for each action if templater is enabled on the chain button
       let processedAction = actionArgs.action;
-      if (args.templater && actionArgs.action && actionArgs.action.includes("<%")) {
+      let processedType = actionArgs.type;
+      
+      if (args.templater) {
         try {
           const activeFile = file || app.workspace.getActiveFile();
           if (activeFile) {
             const runTemplater = await templater(app, activeFile, activeFile);
             if (runTemplater) {
-              processedAction = await runTemplater(actionArgs.action);
+              // Process action field if it contains templater expressions
+              if (actionArgs.action && actionArgs.action.includes("<%")) {
+                processedAction = await runTemplater(actionArgs.action);
+              }
+              
+              // Process type field if it contains templater expressions (for note titles)
+              if (actionArgs.type && actionArgs.type.includes("<%")) {
+                processedType = await runTemplater(actionArgs.type);
+              }
             }
           }
         } catch (error) {
@@ -44,8 +54,9 @@ export const chain = async (
         }
       }
       
-      // Update the action with the processed templater result
+      // Update the action and type with the processed templater results
       actionArgs.action = processedAction;
+      actionArgs.type = processedType;
       
       // Recalculate position for each action if needed
       let currentPosition = position;

--- a/src/livePreview.ts
+++ b/src/livePreview.ts
@@ -226,12 +226,22 @@ class ButtonWidget extends WidgetType {
     
     // Process templater commands for all buttons with templater true
     let processedAction = args.action;
-    if (args.templater && args.action && args.action.includes("<%")) {
+    let processedType = args.type;
+    
+    if (args.templater) {
       try {
         // Both template and target are activeFile since we're processing templater commands within the same file
         const runTemplater = await templater(this.app, activeFile, activeFile);
         if (runTemplater) {
-          processedAction = await runTemplater(args.action);
+          // Process action field if it contains templater expressions
+          if (args.action && args.action.includes("<%")) {
+            processedAction = await runTemplater(args.action);
+          }
+          
+          // Process type field if it contains templater expressions (for note titles)
+          if (args.type && args.type.includes("<%")) {
+            processedType = await runTemplater(args.type);
+          }
         }
       } catch (error) {
         console.error('Error processing templater in button:', error);
@@ -239,8 +249,8 @@ class ButtonWidget extends WidgetType {
       }
     }
 
-    // Create a copy of args with the processed action to avoid mutating the original
-    const processedArgs = { ...args, action: processedAction };
+    // Create a copy of args with the processed values to avoid mutating the original
+    const processedArgs = { ...args, action: processedAction, type: processedType };
     
     const buttonStart = await getInlineButtonPosition(this.app, this.id);
     let position = await getInlineButtonPosition(this.app, this.id);


### PR DESCRIPTION
This PR fixes issue #276 where templater substitutions in note titles were being cut off due to the regex not properly handling nested parentheses in templater expressions.

## Problem
When using a button like:
```button
name Create Daily Note
type note(<% tp.date.now("YYYY-MM-DD") %> Daily) text
action Example Content
templater true
```

**Expected behavior:** Creates a file called `2025-01-14 Daily.md`
**Actual behavior:** Creates a file called `<% tp.date.now("YYYY-MM-DD".md`

## Root Cause
The templater processing was only applied to the `action` field but not the `type` field which contains the note title. When the regex in `createNote.ts` tried to extract the note title from the raw templater expression, it would stop at the first closing parenthesis, truncating the templater expression.

## Solution
Extended the templater processing logic in three files to handle both `action` and `type` fields:
- `src/button.ts` - Main button click handler
- `src/livePreview.ts` - Live preview button handler 
- `src/buttonTypes/chain.ts` - Chain button handler

Now when a button with `templater true` is clicked:
1. Templater expressions in both action and type fields are processed
2. The processed type field (with resolved templater expressions) is passed to `createNote`
3. The regex correctly extracts the note title from the processed string

## Testing
- Code compiles successfully with `npm run build`
- All existing functionality preserved
- Templater expressions in note titles now work as expected

Fixes #276