### PR TITLE
Fix templater expressions in folder field

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -134,6 +134,7 @@ const clickHandler = async (
   // Process templater commands for all buttons with templater true
   let processedAction = args.action;
   let processedType = args.type;
+  let processedFolder = args.folder;
   
   if (args.templater) {
     try {
@@ -149,6 +150,11 @@ const clickHandler = async (
         if (args.type && args.type.includes("<%")) {
           processedType = await runTemplater(args.type);
         }
+        
+        // Process folder field if it contains templater expressions
+        if (args.folder && args.folder.includes("<%")) {
+          processedFolder = await runTemplater(args.folder);
+        }
       }
     } catch (error) {
       console.error('Error processing templater in button:', error);
@@ -157,7 +163,7 @@ const clickHandler = async (
   }
 
   // Create a copy of args with the processed values to avoid mutating the original
-  const processedArgs = { ...args, action: processedAction, type: processedType };
+  const processedArgs = { ...args, action: processedAction, type: processedType, folder: processedFolder };
   
   if (args.replace) {
     replace(app, processedArgs, position);

--- a/src/buttonTypes/chain.ts
+++ b/src/buttonTypes/chain.ts
@@ -30,6 +30,7 @@ export const chain = async (
       // Process templater commands for each action if templater is enabled on the chain button
       let processedAction = actionArgs.action;
       let processedType = actionArgs.type;
+      let processedFolder = actionArgs.folder;
       
       if (args.templater) {
         try {
@@ -46,6 +47,11 @@ export const chain = async (
               if (actionArgs.type && actionArgs.type.includes("<%")) {
                 processedType = await runTemplater(actionArgs.type);
               }
+              
+              // Process folder field if it contains templater expressions
+              if (actionArgs.folder && actionArgs.folder.includes("<%")) {
+                processedFolder = await runTemplater(actionArgs.folder);
+              }
             }
           }
         } catch (error) {
@@ -54,9 +60,10 @@ export const chain = async (
         }
       }
       
-      // Update the action and type with the processed templater results
+      // Update the action, type, and folder with the processed templater results
       actionArgs.action = processedAction;
       actionArgs.type = processedType;
+      actionArgs.folder = processedFolder;
       
       // Recalculate position for each action if needed
       let currentPosition = position;

--- a/src/livePreview.ts
+++ b/src/livePreview.ts
@@ -227,6 +227,7 @@ class ButtonWidget extends WidgetType {
     // Process templater commands for all buttons with templater true
     let processedAction = args.action;
     let processedType = args.type;
+    let processedFolder = args.folder;
     
     if (args.templater) {
       try {
@@ -242,6 +243,11 @@ class ButtonWidget extends WidgetType {
           if (args.type && args.type.includes("<%")) {
             processedType = await runTemplater(args.type);
           }
+          
+          // Process folder field if it contains templater expressions
+          if (args.folder && args.folder.includes("<%")) {
+            processedFolder = await runTemplater(args.folder);
+          }
         }
       } catch (error) {
         console.error('Error processing templater in button:', error);
@@ -250,7 +256,7 @@ class ButtonWidget extends WidgetType {
     }
 
     // Create a copy of args with the processed values to avoid mutating the original
-    const processedArgs = { ...args, action: processedAction, type: processedType };
+    const processedArgs = { ...args, action: processedAction, type: processedType, folder: processedFolder };
     
     const buttonStart = await getInlineButtonPosition(this.app, this.id);
     let position = await getInlineButtonPosition(this.app, this.id);


### PR DESCRIPTION
This PR extends the fix for issue #276 to also handle templater expressions in the `folder` field.

## Problem
Similar to the note title issue, the `folder` field was not being processed for templater expressions. When users tried to use dynamic folder paths like:

```button
name Create Note in Date Folder
type note(MyNote) text
action Example Content
folder <% tp.date.now("YYYY/MM") %>
templater true
```

**Expected behavior:** Creates a note in a folder like `2025/01/MyNote.md`
**Actual behavior:** Creates a note in a literal folder named `<% tp.date.now("YYYY/MM") %>/MyNote.md`

## Root Cause
The templater processing logic was only applied to `action` and `type` fields, but not to the `folder` field. When `createNote.ts` constructed the folder path, it received the raw templater expression instead of the processed folder name.

## Solution
Extended the templater processing logic in the same three files to also handle the `folder` field:
- `src/button.ts` - Main button click handler
- `src/livePreview.ts` - Live preview button handler 
- `src/buttonTypes/chain.ts` - Chain button handler

Now when a button with `templater true` is clicked:
1. Templater expressions in action, type, AND folder fields are processed
2. The processed folder field (with resolved templater expressions) is passed to `createNote`
3. Dynamic folder paths work as expected

## Testing
- Code compiles successfully with `npm run build`
- All existing functionality preserved
- Templater expressions in folder paths now work correctly
- Consistent with the fix applied to note titles in PR #277

This complements the previous fix for note titles and ensures templater expressions work consistently across all button fields.