### PR TITLE
Fix: match block button position by id first (fixes #282)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,6 @@
 import { App } from "obsidian";
 import { Arguments, Position } from "./types";
+import { getStore } from "./buttonStore";
 import { createContentArray } from "./utils";
 
 export const getButtonPosition = (
@@ -54,6 +55,24 @@ export const getInlineButtonPosition = async (
       });
     });
   return position;
+};
+
+export const getBlockButtonPositionById = async (
+  app: App,
+  id: string
+): Promise<Position | undefined> => {
+  const store = getStore(app.isMobile);
+  if (!store || !id) return undefined;
+  const activeFile = app.workspace.getActiveFile();
+  if (!activeFile) return undefined;
+  const button = store.find(
+    (item) => item.id === `button-${id}` && item.path === activeFile.path
+  );
+  if (!button) return undefined;
+  return {
+    lineStart: button.position.start.line,
+    lineEnd: button.position.end.line,
+  };
 };
 
 export const findNumber = async (


### PR DESCRIPTION
This PR fixes a bug where multiple buttons with the same name in a single note caused clicks to target the wrong block.\n\nChanges:\n- Add `getBlockButtonPositionById` to resolve block positions via the indexed store (by id + file path).\n- Update click handling to use id-first resolution, with a fallback to existing name-based `getButtonPosition`.\n- Keeps inline logic unchanged (still id-based).\n\nWhy:\n- Name-based matching returned the last matching block, so clicking the first deleted the last first, then second, then first.\n\nTesting:\n- Linted changed files; no linter errors.\n- Built the project successfully.\n- Manual reasoning: when ids are present, actions use the exact block; if missing, behavior falls back to legacy name-based lookup.\n\nThis should resolve #282.